### PR TITLE
Replace block manager id with executor id to identify reduce status

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -284,7 +284,7 @@ private[spark] abstract class MapOutputTracker(conf: SparkConf) extends Logging 
       if (fetchedStatuses != null) {
         logInfo(s"frankfzw: Got the reduce locations for shuffle ${shuffleId}")
         for (s <- fetchedStatuses)
-          logInfo(s"frankfzw: ShuffleId: ${shuffleId}; reduceId: ${s.partition}; blockmanager: ${s.blockManagerId}")
+          logInfo(s"frankfzw: ShuffleId: ${shuffleId}; reduceId: ${s.partition}; executorId: ${s.executorId}")
         return fetchedStatuses
       } else {
         logInfo(s"frankfzw: Missing all reduce locations for shuffle ${shuffleId}. Is it because there is no pending stage?")
@@ -435,7 +435,7 @@ private[spark] class MapOutputTrackerMaster(conf: SparkConf)
     } else {
       logInfo("frankfzw: register shuffle " + shuffleId + " with statuses " + statuses.length)
       for(s <- statuses)
-        logInfo("frankfzw: register shuffle " + shuffleId + " with statuses " + s.partition + ":" + s.blockManagerId)
+        logInfo("frankfzw: register shuffle " + shuffleId + " with statuses " + s.partition + ":" + s.executorId)
       reduceStatuses += (shuffleId -> statuses)
     }
 

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -219,7 +219,7 @@ private[spark] class Executor(
               // }
               var blockManagerInfo: RpcEndpointRef = null
               for (rs <- reduceStatuses) {
-                blockManagerInfo = env.blockManager.getRemoteBlockManager(rs.blockManagerId)
+                blockManagerInfo = env.blockManager.getRemoteBlockManagerInfo(rs.executorId).slaveEndpoint
                 // logInfo(s"frankfzw: Task ${taskId}: The remote BlockManger ID: ${rs.blockManagerId}; reduce ID: ${rs.partition} is ${blockManagerInfo.address}, it has ${rs.getTotalMapPartiton()} partition")
                 reduceIdToBlockManagerInfo += (rs.partition -> blockManagerInfo)
               }

--- a/core/src/main/scala/org/apache/spark/scheduler/ReduceStatus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ReduceStatus.scala
@@ -24,25 +24,21 @@ import org.apache.spark.storage.BlockManagerId
 /**
  * Created by frankfzw on 15-11-9.
  */
-private[spark] class ReduceStatus (p: Int, bId: BlockManagerId) extends Externalizable{
+private[spark] class ReduceStatus(var partition: Int, var executorId: String) extends Externalizable{
 
-  var partition = p
-  var blockManagerId = bId
   private var totalMapPartition:Int = 0;
 
   protected def this() = this(0, null)
 
   override def readExternal(in: ObjectInput): Unit = {
-    blockManagerId = BlockManagerId(in)
-    // blockManagerId.readExternal(in)
     partition = in.readInt()
+    executorId = in.readUTF()
     totalMapPartition = in.readInt()
   }
 
   override def writeExternal(out: ObjectOutput): Unit = {
-    blockManagerId.writeExternal(out)
-    // blockManagerId.writeExternal(out)
     out.writeInt(partition)
+    out.writeUTF(executorId)
     out.writeInt(totalMapPartition)
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -329,12 +329,19 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     }
   }
 
-  def sufficientResourcesRegistered(): Boolean = true
+  // def sufficientResourcesRegistered(): Boolean = true
+  def sufficientResourcesRegistered(): Boolean = {
+    logInfo(s"frankfzw: size: ${executorDataMap.keySet.size}") 
+    executorDataMap.keySet.size > 0
+  }
 
   override def isReady(): Boolean = {
     if (sufficientResourcesRegistered) {
       logInfo("SchedulerBackend is ready for scheduling beginning after " +
-        s"reached minRegisteredResourcesRatio: $minRegisteredRatio")
+        s"reached minRegisteredResourcesRatio: $minRegisteredRatio; size: ${executorDataMap.keySet.size}")
+      for (e <- executorDataMap) {
+        logInfo(s"frankfzw: The executor data of ${e._1} is ${e._2}")
+      }
       return true
     }
     if ((System.currentTimeMillis() - createTime) >= maxRegisteredWaitingTimeMs) {

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -133,6 +133,8 @@ private[spark] class SparkDeploySchedulerBackend(
     memory: Int) {
     logInfo("Granted executor ID %s on hostPort %s with %d cores, %s RAM".format(
       fullId, hostPort, cores, Utils.megabytesToString(memory)))
+    val executorId = fullId.split("/")(1)
+    sc.dagScheduler.executors += executorId
   }
 
   override def executorRemoved(fullId: String, message: String, exitStatus: Option[Int]) {

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -185,6 +185,15 @@ private[spark] class BlockManager(
     master.getRemoteBlockManager(bId)
   }
 
+  /**
+   * added by BeforeRain
+   * Look up BlockManagerInfo for a given executor 
+   * @param executorId
+   * @return BlockManagerInfo
+   */
+  def getRemoteBlockManagerInfo(executorId: String): BlockManagerInfo = {
+    master.getRemoteBlockManagerInfo(executorId)
+  }
 
   /**
    * added by frankfzw
@@ -1409,8 +1418,8 @@ private[spark] object BlockManager extends Logging {
 
   def registerShufflePipe(blockManagerMaster: BlockManagerMaster, shuffleId: Int, reduceStatuses: Array[ReduceStatus]): Boolean = {
     for(rs <- reduceStatuses) {
-      val rpc = blockManagerMaster.getRemoteBlockManager(rs.blockManagerId)
-      logInfo(s"frankfzw: registerShufflePipe id: ${shuffleId}; target blockmanager ${rs.blockManagerId}; total map: ${rs.getTotalMapPartiton()}; total reduce: ${reduceStatuses.length}; reduce id: ${rs.partition}")
+      val rpc = blockManagerMaster.getRemoteBlockManagerInfo(rs.executorId).slaveEndpoint
+      logInfo(s"frankfzw: registerShufflePipe id: ${shuffleId}; target executor id: ${rs.executorId}; total map: ${rs.getTotalMapPartiton()}; total reduce: ${reduceStatuses.length}; reduce id: ${rs.partition}")
       // if (!rpc.askWithRetry[Boolean](RegisterShufflePipe(shuffleId, rs.getTotalMapPartiton(), rs.partition, reduceStatuses.length)))
       //   throw new SparkException(s"frankfzw: RegisterShufflePipe faild: id: ${shuffleId}; target blockmanager ${rs.blockManagerId}; total map: ${rs.getTotalMapPartiton()}; total reduce: ${reduceStatuses.length}; reduce id: ${rs.partition}")
       //   return false

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMaster.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMaster.scala
@@ -51,6 +51,17 @@ class BlockManagerMaster(
     // logInfo(s"frankfzw: Get ${blockManagerId}")
     driverEndpoint.askWithRetry[RpcEndpointRef](AskForRemoteBlockManager(blockManagerId))
   }
+
+  /**
+   * added by BeforeRain
+   * Look up BlockManagerInfo for a given executor 
+   * @param executorId
+   * @return BlockManagerInfo
+   */
+  def getRemoteBlockManagerInfo(executorId: String): BlockManagerInfo = {
+    driverEndpoint.askWithRetry[BlockManagerInfo](AskForRemoteBlockManagerInfo(executorId))
+  }
+
   /**
    * Get the all active BlockManagerId for random allocation
    * added by frankfzw

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMessages.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMessages.scala
@@ -115,6 +115,9 @@ private[spark] object BlockManagerMessages {
   // added by frankfzw. Fetch the remote blockMangerSlaveEndPoint
   case class AskForRemoteBlockManager(blockManagerId: BlockManagerId) extends ToBlockManagerMaster
 
+  // added by BeforeRain. Fetch BlockManagerInfo for a given executor
+  case class AskForRemoteBlockManagerInfo(executorId: String) extends ToBlockManagerMaster
+
   case class WriteRemote(shuffleId: Int, reduceId: Int, key: Any, value: Any) extends ToBlockManagerSlave
 
   case class RegisterShufflePipe(shuffleId: Int, totalMapPartition: Int, reducePartition: Int, totalReducePartiton: Int) extends ToBlockManagerSlave


### PR DESCRIPTION
Replace block manager id with executor id to identify reduce status, in case block managers not registered in time